### PR TITLE
Fix/remove pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.4.0"
+version = "0.4.1"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/__init__.py
+++ b/src/launch/__init__.py
@@ -1,6 +1,6 @@
 from semver import Version
 
-VERSION = "0.4.0"
+VERSION = "0.4.1"
 
 SEMANTIC_VERSION = Version.parse(VERSION)
 GITHUB_ORG_NAME = "launchbynttdata"

--- a/src/launch/service/common.py
+++ b/src/launch/service/common.py
@@ -6,9 +6,9 @@ import uuid
 from pathlib import Path
 from typing import List
 
-import yaml
 from git.repo import Repo
 from jinja2 import Environment, FileSystemLoader
+from ruamel.yaml import YAML
 
 from launch import BUILD_DEPENDENCIES_DIR, SERVICE_SKELETON, SKELETON_BRANCH
 from launch.automation.common.functions import (
@@ -173,14 +173,14 @@ def write_text(
 ) -> None:
     if output_format == "json":
         serialized_data = json.dumps(data, indent=indent)
+        path.write_text(serialized_data)
     elif output_format == "yaml":
-        serialized_data = yaml.dump(data, indent=indent)
+        yaml = YAML()
+        yaml.dump(data=data, stream=path)
     else:
         message = f"Unsupported output format: {output_format}"
         logger.error(message)
         raise ValueError(message)
-
-    path.write_text(serialized_data)
 
 
 def input_data_validation(input_data: dict) -> dict:

--- a/test/unit/service/common/test_callback_copy_properties_files.py
+++ b/test/unit/service/common/test_callback_copy_properties_files.py
@@ -18,7 +18,7 @@ def fakedata():
 
 @pytest.fixture
 def setup_file_structure(fakedata, tmp_path):
-    base_path = f"tmp_path/base/"
+    base_path = str(tmp_path) + "/base/"
     current_path = "current/path"
     (Path(base_path) / current_path).mkdir(parents=True, exist_ok=True)
 

--- a/test/unit/service/common/test_write_text.py
+++ b/test/unit/service/common/test_write_text.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+from launch.automation.common.functions import load_yaml
 from launch.service.common import write_text
 
 
@@ -20,16 +21,16 @@ def test_write_text_json(fakedata):
     test_path.write_text.assert_called_once_with(serialized_data)
 
 
-def test_write_text_yaml(fakedata):
-    serialized_data = yaml.dump(fakedata["copy_and_render"]["context_data"])
-    test_path = MagicMock(spec=Path)
-    test_path.write_text.return_value = MagicMock()
+def test_write_text_yaml(fakedata, tmp_path):
+    serialized_data = fakedata["copy_and_render"]["context_data"]
+    target_path = tmp_path.joinpath("sample.yaml")
     write_text(
-        path=test_path,
-        data=fakedata["copy_and_render"]["context_data"],
+        path=target_path,
+        data=serialized_data,
         output_format="yaml",
     )
-    test_path.write_text.assert_called_once_with(serialized_data)
+    deserialized = load_yaml(yaml_file=target_path)
+    assert deserialized == serialized_data
 
 
 def test_write_text_unsupported_format(fakedata):


### PR DESCRIPTION
Resolves issues with the latest 0.4.0 release that weren't immediately apparent on migration:

* PyYAML is not one of our dependencies, references have been updated to use `ruamel.yaml` (which is compliant with YAML >= 1.2 and is already part of our dependencies)
* One of the test fixtures wasn't using the tmp_path filter as intended and was leaving testing paths in the `cwd`, this is now resolved.

Once merged, I'll tag and release this as `0.4.1` to PyPI.