### PR TITLE
Add CLI run that doesn't install dev dependencies

### DIFF
--- a/.github/workflows/cli_test.yaml
+++ b/.github/workflows/cli_test.yaml
@@ -1,0 +1,30 @@
+name: CLI Tests
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install .
+    - name: Validate launch command can be run without having dev dependencies installed
+      run: |
+        launch --help


### PR DESCRIPTION
Our main test workflow, `test.yaml` runs unit tests but in order to do so, it installs dev dependencies. This masks a failure condition where application code relies on those dev dependencies, like we encountered with PyYAML.

This test workflow installs the `launch-cli` tooling without dev dependencies and attempts to run the tool. This should shake out any hidden dev dependencies going forward.

Note that these tests won't actually pass until #1 is merged to correct the dependency issue.