### PR TITLE
Fix/dependabot pr handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.6.0"
+version = "0.6.1"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/__init__.py
+++ b/src/launch/__init__.py
@@ -1,6 +1,6 @@
 from semver import Version
 
-VERSION = "0.6.0"
+VERSION = "0.6.1"
 
 SEMANTIC_VERSION = Version.parse(VERSION)
 GITHUB_ORG_NAME = "launchbynttdata"

--- a/src/launch/local_repo/predict.py
+++ b/src/launch/local_repo/predict.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 BRANCH_DELIMITER = "/"
 
-PATCH_NAME_PARTS = ["fix", "bug", "patch"]
+PATCH_NAME_PARTS = ["fix", "bug", "patch", "dependabot"]
 MINOR_NAME_PARTS = ["feature"]
 MAJOR_NAME_PARTS = []
 

--- a/test/unit/cli/validate/test_branch_name.py
+++ b/test/unit/cli/validate/test_branch_name.py
@@ -11,6 +11,7 @@ ACCEPTABLE_BRANCH_NAMES = [
     "BUG/ok",
     "BUG!/ok",
     "!buG/ok",
+    "dependabot/ok",
     "feature/ok",
     "feature!/ok",
     "Feature/ok",

--- a/test/unit/local_repo/test_predict.py
+++ b/test/unit/local_repo/test_predict.py
@@ -50,10 +50,12 @@ def test_latest_tag():
         ["fix/should-patch", Version(1, 0, 1), does_not_raise()],
         ["bug/should-patch", Version(1, 0, 1), does_not_raise()],
         ["patch/should-patch", Version(1, 0, 1), does_not_raise()],
+        ["dependabot/should-patch", Version(1, 0, 1), does_not_raise()],
         ["feature/should-minor", Version(1, 1, 0), does_not_raise()],
         ["fix!/breaking-char-should-major", Version(2, 0, 0), does_not_raise()],
         ["Fix/breaking-cap-should-major", Version(2, 0, 0), does_not_raise()],
         ["bad/name", Version(2, 0, 0), pytest.raises(InvalidBranchNameException)],
+        ["bad_name", Version(2, 0, 0), pytest.raises(InvalidBranchNameException)],
         ["feat/is-not-valid-anymore", None, pytest.raises(InvalidBranchNameException)],
         [
             "release/is-not-valid-anymore",


### PR DESCRIPTION
Adds `dependabot/` as a valid prefix for branch name recognition.

A dependabot PR is treated as a patch version bump, equivalent to `fix/`, `patch/` and `bug/`.

This will be released as version `0.6.1`.