### PR TITLE
Repo without tags defaults to version 1.0.0, not 0.1.0

### DIFF
--- a/src/launch/local_repo/predict.py
+++ b/src/launch/local_repo/predict.py
@@ -17,7 +17,7 @@ ALL_NAME_PARTS = list(
 
 BREAKING_CHARS = ["!"]
 CAPITALIZE_FIRST_IS_BREAKING = True
-DEFAULT_VERSION = Version(major=0, minor=1, patch=0)
+DEFAULT_VERSION = Version(major=1, minor=0, patch=0)
 
 
 class InvalidBranchNameException(Exception):

--- a/test/unit/local_repo/test_predict.py
+++ b/test/unit/local_repo/test_predict.py
@@ -73,3 +73,13 @@ def test_predict(branch_name: str, expected_version: Version, raises):
             existing_tags=existing_tags, branch_name=branch_name
         )
         assert new_version == expected_version
+
+
+@pytest.mark.parametrize(
+    "branch_name", ["fix/no-tags-yet", "feature/no-tags-yet", "patch!/no-tags-yet"]
+)
+def test_predict_default_version(branch_name: str):
+    existing_tags = []
+    expected_version = Version(1, 0, 0)
+    new_version = predict_version(existing_tags=existing_tags, branch_name=branch_name)
+    assert new_version == expected_version


### PR DESCRIPTION
Will be released as `0.6.2`.