### PR TITLE
Add commands to interrogate and create our custom GitHub labels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.6.1"
+version = "0.7.0"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/__init__.py
+++ b/src/launch/__init__.py
@@ -1,6 +1,6 @@
 from semver import Version
 
-VERSION = "0.6.1"
+VERSION = "0.7.0"
 
 SEMANTIC_VERSION = Version.parse(VERSION)
 GITHUB_ORG_NAME = "launchbynttdata"

--- a/src/launch/cli/github/repo/__init__.py
+++ b/src/launch/cli/github/repo/__init__.py
@@ -1,6 +1,6 @@
 import click
 
-from .commands import create
+from .commands import check_labels, create, create_labels
 
 
 @click.group(name="repo")
@@ -9,3 +9,5 @@ def repo_group():
 
 
 repo_group.add_command(create)
+repo_group.add_command(check_labels)
+repo_group.add_command(create_labels)

--- a/src/launch/github/labels.py
+++ b/src/launch/github/labels.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+
+from github.GithubException import GithubException
+from github.Repository import Repository
+
+
+@dataclass
+class CustomLabel:
+    name: str
+    color: str
+    description: str
+
+
+CUSTOM_LABELS = [
+    CustomLabel(
+        name="dependencies",
+        color="0366d6",
+        description="Pull requests that update a dependency file",
+    ),
+    CustomLabel(
+        name="breaking",
+        color="b60205",
+        description="Pull requests that contain a breaking change",
+    ),
+]
+
+
+def has_custom_labels(
+    repository: Repository, custom_labels: list[CustomLabel] = None
+) -> bool:
+    """Determines whether a repository has all the custom labels that we expect.
+
+    Args:
+        repository (Repository): GitHub Repository
+        custom_labels (list[CustomLabel], optional): List of labels to check. Defaults to None, which will pull the standard custom labels from the module.
+
+    Returns:
+        bool: True if all expected custom labels were found, False otherwise.
+    """
+    if not custom_labels:
+        custom_labels = CUSTOM_LABELS
+    all_labels = [label for label in repository.get_labels()]
+    return all(
+        [
+            custom_label.name in [label.name for label in all_labels]
+            for custom_label in custom_labels
+        ]
+    )
+
+
+def create_custom_labels(
+    repository: Repository, custom_labels: list[CustomLabel] = None
+) -> int:
+    """Creates custom labels on a given GitHub repository, returning the number of labels that were created.
+    This can be run many times against the same repository without creating problems.
+
+    Args:
+        repository (Repository): GitHub Repository
+        custom_labels (list[CustomLabel], optional): List of labels to create. Defaults to None, which will pull the standard custom labels from the module.
+
+    Returns:
+        int: Number of labels created.
+    """
+    if not custom_labels:
+        custom_labels = CUSTOM_LABELS
+    num_created = 0
+    for custom_label in custom_labels:
+        try:
+            repository.create_label(
+                name=custom_label.name,
+                color=custom_label.color.strip("#"),
+                description=custom_label.description.strip(),
+            )
+            num_created += 1
+        except GithubException as ghe:
+            if "already_exists" in ghe._GithubException__data.get("errors", [{}])[
+                0
+            ].get("code", ""):
+                pass
+            else:
+                raise
+    return num_created

--- a/test/unit/cli/github/test_check_labels.py
+++ b/test/unit/cli/github/test_check_labels.py
@@ -1,0 +1,31 @@
+from launch.cli.github.repo.commands import check_labels, create_labels
+
+
+class TestCheckLabels:
+    def test_check_labels_ok(self, cli_runner, mocker):
+        _ = mocker.patch("launch.cli.github.repo.commands.get_github_instance")
+        patched_labels = mocker.patch(
+            "launch.cli.github.repo.commands.has_custom_labels"
+        )
+        patched_labels.return_value = True
+
+        result = cli_runner.invoke(
+            check_labels,
+            ["--repository-name", "phony_name"],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+
+    def test_check_labels_not_ok(self, cli_runner, mocker):
+        _ = mocker.patch("launch.cli.github.repo.commands.get_github_instance")
+        patched_labels = mocker.patch(
+            "launch.cli.github.repo.commands.has_custom_labels"
+        )
+        patched_labels.return_value = False
+
+        result = cli_runner.invoke(
+            check_labels,
+            ["--repository-name", "phony_name"],
+        )
+        assert result.exception
+        assert result.exit_code == 1

--- a/test/unit/cli/github/test_create_labels.py
+++ b/test/unit/cli/github/test_create_labels.py
@@ -1,0 +1,40 @@
+import logging
+
+import pytest
+from github.GithubException import GithubException
+
+from launch.cli.github.repo.commands import create_labels
+
+
+class TestCreateLabels:
+    @pytest.mark.parametrize("labels_created", [0, 1, 1000])
+    def test_create_labels_ok(self, labels_created: int, cli_runner, mocker, caplog):
+        _ = mocker.patch("launch.cli.github.repo.commands.get_github_instance")
+        patched_labels = mocker.patch(
+            "launch.cli.github.repo.commands.create_custom_labels"
+        )
+        patched_labels.return_value = labels_created
+        with caplog.at_level(level=logging.INFO):
+            result = cli_runner.invoke(
+                create_labels,
+                ["--repository-name", "phony_name"],
+            )
+            assert not result.exception
+            assert result.exit_code == 0
+            assert str(labels_created) in caplog.text
+
+    def test_create_labels_error(self, cli_runner, mocker, caplog):
+        _ = mocker.patch("launch.cli.github.repo.commands.get_github_instance")
+        patched_labels = mocker.patch(
+            "launch.cli.github.repo.commands.create_custom_labels"
+        )
+        patched_labels.side_effect = GithubException(
+            status=422, data={"errors": [{"code": "something_else"}]}
+        )
+        with caplog.at_level(level=logging.INFO):
+            result = cli_runner.invoke(
+                create_labels,
+                ["--repository-name", "phony_name"],
+            )
+            assert result.exception
+            assert result.exit_code != 0

--- a/test/unit/github/test_labels.py
+++ b/test/unit/github/test_labels.py
@@ -1,0 +1,70 @@
+import logging
+
+import pytest
+from github.GithubException import GithubException
+from github.Label import Label
+from semver import Version
+
+from launch.github import tags
+from launch.github.labels import CUSTOM_LABELS, create_custom_labels, has_custom_labels
+
+
+@pytest.fixture
+def mocked_repository(mocker):
+    mocked_repo = mocker.MagicMock()
+    mocked_repo.name = "mocked_repo"
+    yield mocked_repo
+
+
+class TestHasCustomLabels:
+    def test_has_custom_labels_no_labels(self, mocked_repository):
+        mocked_repository.get_labels.return_value = []
+        assert not has_custom_labels(repository=mocked_repository)
+
+    def test_has_custom_labels_some_labels(self, mocked_repository):
+        mocked_repository.get_labels.return_value = [CUSTOM_LABELS[0]]
+        assert not has_custom_labels(repository=mocked_repository)
+
+    def test_has_custom_labels_all_labels(self, mocked_repository):
+        mocked_repository.get_labels.return_value = CUSTOM_LABELS
+        assert has_custom_labels(repository=mocked_repository)
+
+
+class TestCreateCustomLabels:
+    def test_create_custom_labels(self, mocked_repository, mocker):
+        expected_calls = []
+        for custom_label in CUSTOM_LABELS:
+            expected_calls.append(
+                mocker.call(
+                    name=custom_label.name,
+                    color=custom_label.color,
+                    description=custom_label.description,
+                )
+            )
+
+        num_created = create_custom_labels(repository=mocked_repository)
+        mocked_repository.create_label.assert_has_calls(expected_calls)
+
+        assert num_created == len(CUSTOM_LABELS)
+        assert mocked_repository.create_label.call_count == len(CUSTOM_LABELS)
+
+    def test_create_custom_labels_already_exist(self, mocked_repository, mocker):
+        mocked_repository.create_label.side_effect = GithubException(
+            status=422, data={"errors": [{"code": "already_exists"}]}
+        )
+
+        expected_calls = []
+        for custom_label in CUSTOM_LABELS:
+            expected_calls.append(
+                mocker.call(
+                    name=custom_label.name,
+                    color=custom_label.color,
+                    description=custom_label.description,
+                )
+            )
+
+        num_created = create_custom_labels(repository=mocked_repository)
+        mocked_repository.create_label.assert_has_calls(expected_calls)
+
+        assert num_created == 0
+        assert mocked_repository.create_label.call_count == len(CUSTOM_LABELS)


### PR DESCRIPTION
These commands will be utilized by an upcoming Github Action workflow to drive release template creation where appropriate.

We're going to skip releasing `0.6.2` as planned and just release this as `0.7.0`.

```
$ launch github repo check-labels --help
Usage: launch github repo check-labels [OPTIONS]

  Check a repository to see if it has all of the custom labels we expect for
  GitHub Actions. If the repository is missing labels, a non-zero error code
  will be returned!

Options:
  --repository-name TEXT  [required]
  --organization TEXT
  --help                  Show this message and exit.

$ launch github repo create-labels --help
Usage: launch github repo create-labels [OPTIONS]

  Creates custom labels for GitHub Actions on a repository. If the repository
  has all the expected labels, this will return successfully with a message
  showing zero labels created, allowing this command to be safely rerun
  against a repository multiple times.

Options:
  --repository-name TEXT  [required]
  --organization TEXT
  --help                  Show this message and exit.
```