### PR TITLE
changing logic of the env var

### DIFF
--- a/src/launch/env.py
+++ b/src/launch/env.py
@@ -67,8 +67,8 @@ def override_default(
     Returns:
         str: The value of the key in the launchconfig file or the default value
     """
-    if get_bool_env_var(key_name, False):
-        return os.environ.get(key_name, default=default)
+    if os.environ.get(key_name):
+        return os.environ.get(key_name)
 
     if Path(LAUNCHCONFIG_PATH_LOCAL).exists():
         with open(LAUNCHCONFIG_PATH_LOCAL, "r") as f:


### PR DESCRIPTION
changing logic of checking a env var to a simple `os.environ.get`.