### PR TITLE
fixing github auth bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.9.5"
+version = "0.9.6"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/cli/github/auth/commands.py
+++ b/src/launch/cli/github/auth/commands.py
@@ -43,8 +43,8 @@ def application(
     token_expiration_seconds: int,
 ):
     token = get_token(
-        application_id_parameter_name=application_id_parameter_name,
-        installation_id_parameter_name=installation_id_parameter_name,
+        application_id=application_id_parameter_name,
+        installation_id=installation_id_parameter_name,
         signing_cert_secret_name=signing_cert_secret_name,
         token_expiration_seconds=token_expiration_seconds,
     )

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.9.5"
+VERSION = "0.9.6"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/test/unit/lib/github/generate_github_token/test_get_token.py
+++ b/test/unit/lib/github/generate_github_token/test_get_token.py
@@ -28,10 +28,10 @@ def mock_dependencies():
 
 def test_get_token_success(mock_dependencies):
     token = get_token(
-        "application_id",
-        "installation_id",
-        "signing_cert_secret_name",
-        "token_expiration_seconds",
+        application_id="application_id",
+        installation_id="installation_id",
+        signing_cert_secret_name="signing_cert_secret_name", # pragma: allowlist secret
+        token_expiration_seconds="token_expiration_seconds",
     )
 
     # Assert that the token returned is as expected
@@ -50,10 +50,10 @@ def test_get_token_failure(mock_dependencies):
             {"Error": {"Code": "TestException"}}, "test_operation"
         )
         get_token(
-            "application_id",
-            "installation_id",
-            "signing_cert_secret_name",
-            "token_expiration_seconds",
+            application_id="application_id",
+            installation_id="installation_id",
+            signing_cert_secret_name="signing_cert_secret_name", # pragma: allowlist secret
+            token_expiration_seconds="token_expiration_seconds",
         )
     mock_dependencies["post"].assert_not_called()
 


### PR DESCRIPTION
- fixing one of the input params of github auth to correct var from `application_id_parameter_name` to `application_id`