### PR TITLE
Improve .tool-versions plugin handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.9.9"
+version = "0.10.1"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.9.8"
+version = "0.9.9"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.9.9"
+VERSION = "0.10.1"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.9.8"
+VERSION = "0.9.9"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/test/unit/lib/automation/environment/functions/test_install_tool_versions.py
+++ b/test/unit/lib/automation/environment/functions/test_install_tool_versions.py
@@ -3,11 +3,21 @@ from unittest.mock import mock_open
 
 import pytest
 
-from launch.lib.automation.environment.functions import install_tool_versions
+from launch.lib.automation.environment.functions import (
+    install_tool_versions,
+    parse_plugin_line,
+)
+
+EXAMPLE_TOOL_VERSIONS = """
+tool1 1.0.0
+tool2 2.0.0
+tool3 3.0.0-alpha #https://github.com/org/tool3
+tool4 4.0.0-beta # https://github.com/org/tool4
+"""
 
 
 def test_install_tool_versions_success(mocker):
-    mocker.patch("builtins.open", mock_open(read_data="tool1\n tool2"))
+    mocker.patch("builtins.open", mock_open(read_data=EXAMPLE_TOOL_VERSIONS))
     mock_run = mocker.patch("subprocess.run")
 
     install_tool_versions("fake_file")
@@ -16,6 +26,12 @@ def test_install_tool_versions_success(mocker):
         [
             mocker.call(["asdf", "plugin", "add", "tool1"]),
             mocker.call(["asdf", "plugin", "add", "tool2"]),
+            mocker.call(
+                ["asdf", "plugin", "add", "tool3", "https://github.com/org/tool3"]
+            ),
+            mocker.call(
+                ["asdf", "plugin", "add", "tool4", "https://github.com/org/tool4"]
+            ),
             mocker.call(["asdf", "install"]),
         ]
     )
@@ -29,10 +45,37 @@ def test_install_tool_versions_file_read_exception(mocker):
 
 
 def test_install_tool_versions_subprocess_exception(mocker):
-    mocker.patch("builtins.open", mock_open(read_data="tool1\n tool2"))
+    mocker.patch("builtins.open", mock_open(read_data=EXAMPLE_TOOL_VERSIONS))
     mocker.patch(
         "subprocess.run", side_effect=subprocess.CalledProcessError(1, ["asdf"])
     )
 
     with pytest.raises(RuntimeError, match="An error occurred with asdf install"):
         install_tool_versions("fake_file")
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("pre-commit 3.3.3", ("pre-commit", "3.3.3", None)),
+        ("pre-commit 3.3.3 # just a comment, not a URL", ("pre-commit", "3.3.3", None)),
+        (
+            "repo-tool v2.10.3-launch # https://github.com/launchbynttdata/asdf-repo-tool",
+            (
+                "repo-tool",
+                "v2.10.3-launch",
+                "https://github.com/launchbynttdata/asdf-repo-tool",
+            ),
+        ),
+        (
+            "repo-tool v2.10.3-launch #https://github.com/launchbynttdata/asdf-repo-tool",
+            (
+                "repo-tool",
+                "v2.10.3-launch",
+                "https://github.com/launchbynttdata/asdf-repo-tool",
+            ),
+        ),
+    ],
+)
+def test_parse_plugin_line(line, expected):
+    assert parse_plugin_line(line) == expected


### PR DESCRIPTION
The initial implementation of plugin handling with `asdf` didn't include the logic to install third-party plugins from arbitrary repositories [like we support in the Makefile](https://github.com/launchbynttdata/launch-cli/blob/main/Makefile#L93-L103).

Rather than just an `asdf plugin install foo`, we'll examine the plugin line in the .tool-versions file, and if we find a comment and a URL at the end of the line, we'll `asdf plugin install foo http://example.com`.

This will be released after Kevin's next change and will bump the version to 0.10.1.