### PR TITLE
Copy arbitrary files using .launch_config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.10.1"
+version = "0.11.0"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/cli/service/create/__init__.py
+++ b/src/launch/cli/service/create/__init__.py
@@ -260,6 +260,7 @@ def create_dir_offline(
     )
 
     input_data[PLATFORM_SRC_DIR_PATH] = process_template(
+        repo_base=Path.cwd(),
         dest_base=Path(service_path),
         config={PLATFORM_SRC_DIR_PATH: input_data[PLATFORM_SRC_DIR_PATH]},
         skip_uuid=True,

--- a/src/launch/cli/service/generate/__init__.py
+++ b/src/launch/cli/service/generate/__init__.py
@@ -14,6 +14,7 @@ from launch.lib.common.utilities import extract_repo_name_from_url
 from launch.lib.local_repo.repo import checkout_branch, clone_repository
 from launch.lib.service.common import input_data_validation
 from launch.lib.service.template.functions import (
+    copy_additional_files,
     copy_and_render_templates,
     copy_template_files,
     list_jinja_templates,
@@ -152,6 +153,12 @@ def generate(
         repository_url=skeleton_url,
         target=build_skeleton_path,
         branch=skeleton_tag,
+        dry_run=dry_run,
+    )
+
+    copy_additional_files(
+        platform_config=input_data[PLATFORM_SRC_DIR_PATH],
+        target_dir=Path(build_path_service),
         dry_run=dry_run,
     )
 

--- a/src/launch/cli/service/generate/__init__.py
+++ b/src/launch/cli/service/generate/__init__.py
@@ -14,7 +14,6 @@ from launch.lib.common.utilities import extract_repo_name_from_url
 from launch.lib.local_repo.repo import checkout_branch, clone_repository
 from launch.lib.service.common import input_data_validation
 from launch.lib.service.template.functions import (
-    copy_additional_files,
     copy_and_render_templates,
     copy_template_files,
     list_jinja_templates,
@@ -156,12 +155,6 @@ def generate(
         dry_run=dry_run,
     )
 
-    copy_additional_files(
-        platform_config=input_data[PLATFORM_SRC_DIR_PATH],
-        target_dir=Path(build_path_service),
-        dry_run=dry_run,
-    )
-
     copy_template_files(
         src_dir=Path(build_skeleton_path),
         target_dir=Path(build_path_service),
@@ -169,6 +162,7 @@ def generate(
     )
 
     input_data[PLATFORM_SRC_DIR_PATH] = process_template(
+        repo_base=Path.cwd(),
         dest_base=Path(build_path_service),
         config={PLATFORM_SRC_DIR_PATH: input_data[PLATFORM_SRC_DIR_PATH]},
         skip_uuid=True,

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.10.1"
+VERSION = "0.11.0"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/src/launch/lib/service/functions.py
+++ b/src/launch/lib/service/functions.py
@@ -124,6 +124,7 @@ def common_service_workflow(
     # Process the template files. This is the main logic that loops over the template and
     # creates the directories and files in the service directory.
     input_data[PLATFORM_SRC_DIR_PATH] = process_template(
+        repo_base=Path.cwd(),
         dest_base=Path(service_path),
         config={PLATFORM_SRC_DIR_PATH: input_data[PLATFORM_SRC_DIR_PATH]},
         skip_uuid=not uuid,

--- a/src/launch/lib/service/template/functions.py
+++ b/src/launch/lib/service/template/functions.py
@@ -107,18 +107,17 @@ def copy_additional_files(
                             .joinpath(destination_filename)
                         )
 
-                        create_specific_path(
-                            base_path=destination_path.parent,
-                            path_parts=[],
-                            dry_run=dry_run,
-                        )
-
                         if dry_run:
                             click.secho(
                                 f"[DRYRUN] Copying additional file, would have copied {source_path} to {destination_path}",
                                 fg="yellow",
                             )
                         else:
+                            create_specific_path(
+                                base_path=destination_path.parent,
+                                path_parts=[],
+                                dry_run=dry_run,
+                            )
                             shutil.copyfile(src=source_path, dst=destination_path)
                             click.echo(
                                 f"Copied additional file from {source_path} to {destination_path}"

--- a/src/launch/lib/service/template/functions.py
+++ b/src/launch/lib/service/template/functions.py
@@ -85,6 +85,45 @@ def process_template(
     return updated_config
 
 
+def copy_additional_files(
+    platform_config: dict, target_dir: Path, dry_run: bool = True
+) -> None:
+    for platform_resource_key, platform_resource in platform_config.items():
+        for environment_key, environment in platform_resource.items():
+            for region_key, region in environment.items():
+                for environment_number, numbered_environment in region.items():
+                    for destination_filename, source_file in numbered_environment.get(
+                        "additional_files", {}
+                    ).items():
+                        source_path = Path(source_file)
+                        destination_path = (
+                            Path(target_dir)
+                            .joinpath(PLATFORM_SRC_DIR_PATH)
+                            .joinpath(platform_resource_key)
+                            .joinpath(environment_key)
+                            .joinpath(region_key)
+                            .joinpath(environment_number)
+                            .joinpath(destination_filename)
+                        )
+
+                        create_specific_path(
+                            base_path=destination_path.parent,
+                            path_parts=[],
+                            dry_run=dry_run,
+                        )
+
+                        if dry_run:
+                            click.secho(
+                                f"[DRYRUN] Copying additional file, would have copied {source_path} to {destination_path}",
+                                fg="yellow",
+                            )
+                        else:
+                            shutil.copyfile(src=source_path, dst=destination_path)
+                            click.echo(
+                                f"Copied additional file from {source_path} to {destination_path}"
+                            )
+
+
 def copy_template_files(
     src_dir: Path, target_dir: Path, not_platform: bool = False, dry_run: bool = True
 ) -> None:

--- a/src/launch/lib/service/template/functions.py
+++ b/src/launch/lib/service/template/functions.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def process_template(
+    repo_base: Path,
     dest_base: Path,
     config: dict,
     parent_keys=[],
@@ -55,6 +56,14 @@ def process_template(
                 if key != LAUNCHCONFIG_KEYS.ADDITIONAL_FILES.value:
                     current_path.mkdir(parents=True, exist_ok=True)
 
+            if LAUNCHCONFIG_KEYS.ADDITIONAL_FILES.value in value:
+                LaunchConfigTemplate(dry_run).copy_additional_files(
+                    value=value,
+                    current_path=current_path,
+                    repo_base=repo_base,
+                    dest_base=dest_base,
+                )
+
             if LAUNCHCONFIG_KEYS.PROPERTIES_FILE.value in value:
                 LaunchConfigTemplate(dry_run).properties_file(
                     value=value,
@@ -74,6 +83,7 @@ def process_template(
                     dest_base=dest_base,
                 )
             updated_config[key] = process_template(
+                repo_base=repo_base,
                 dest_base=dest_base,
                 config=value,
                 parent_keys=current_keys,
@@ -84,44 +94,6 @@ def process_template(
             updated_config[key] = value
 
     return updated_config
-
-
-def copy_additional_files(
-    platform_config: dict, target_dir: Path, dry_run: bool = True
-) -> None:
-    for platform_resource_key, platform_resource in platform_config.items():
-        for environment_key, environment in platform_resource.items():
-            for region_key, region in environment.items():
-                for environment_number, numbered_environment in region.items():
-                    for destination_filename, source_file in numbered_environment.get(
-                        "additional_files", {}
-                    ).items():
-                        source_path = Path(source_file)
-                        destination_path = (
-                            Path(target_dir)
-                            .joinpath(PLATFORM_SRC_DIR_PATH)
-                            .joinpath(platform_resource_key)
-                            .joinpath(environment_key)
-                            .joinpath(region_key)
-                            .joinpath(environment_number)
-                            .joinpath(destination_filename)
-                        )
-
-                        if dry_run:
-                            click.secho(
-                                f"[DRYRUN] Copying additional file, would have copied {source_path} to {destination_path}",
-                                fg="yellow",
-                            )
-                        else:
-                            create_specific_path(
-                                base_path=destination_path.parent,
-                                path_parts=[],
-                                dry_run=dry_run,
-                            )
-                            shutil.copyfile(src=source_path, dst=destination_path)
-                            click.echo(
-                                f"Copied additional file from {source_path} to {destination_path}"
-                            )
 
 
 def copy_template_files(

--- a/src/launch/lib/service/template/functions.py
+++ b/src/launch/lib/service/template/functions.py
@@ -52,7 +52,8 @@ def process_template(
                     fg="yellow",
                 )
             else:
-                current_path.mkdir(parents=True, exist_ok=True)
+                if key != LAUNCHCONFIG_KEYS.ADDITIONAL_FILES.value:
+                    current_path.mkdir(parents=True, exist_ok=True)
 
             if LAUNCHCONFIG_KEYS.PROPERTIES_FILE.value in value:
                 LaunchConfigTemplate(dry_run).properties_file(

--- a/src/launch/lib/service/template/launchconfig.py
+++ b/src/launch/lib/service/template/launchconfig.py
@@ -33,6 +33,28 @@ class LaunchConfigTemplate:
             except shutil.SameFileError:
                 pass
 
+    def copy_additional_files(
+        self, value: dict, current_path: Path, repo_base: Path, dest_base: Path
+    ) -> None:
+        # print(f"\n\n{value=}\n{current_path=}\n{repo_base=}\n{dest_base=}\n\n")
+        # breakpoint()
+        for target_file, source_file in value[
+            LAUNCHCONFIG_KEYS.ADDITIONAL_FILES.value
+        ].items():
+            source_path = repo_base.joinpath(source_file)
+            target_path = Path(current_path).joinpath(target_file)
+            if self.dry_run:
+                click.secho(
+                    f"[DRYRUN] Copying additional file, would have copied {source_path} to {target_path}",
+                    fg="yellow",
+                )
+            else:
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(src=source_path, dst=target_path)
+                click.echo(
+                    f"Copied additional file from {source_path} to {target_path}"
+                )
+
     def templates(self, value: dict, current_path: Path, dest_base: Path) -> None:
         for name, templates in value[LAUNCHCONFIG_KEYS.TEMPLATES.value].items():
             logger.info(f"{templates=}")

--- a/test/unit/lib/service/template/functions/test_copy_additional_files.py
+++ b/test/unit/lib/service/template/functions/test_copy_additional_files.py
@@ -1,0 +1,150 @@
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from launch.config.common import BUILD_TEMP_DIR_PATH, PLATFORM_SRC_DIR_PATH
+from launch.lib.service.template.functions import copy_additional_files
+
+
+@pytest.fixture(scope="class")
+def launch_config_file_contents():
+    yield {
+        "provider": "aws",
+        "accounts": {"root": "launch-root-admin"},
+        "naming_prefix": "unit-test",
+        "skeleton": {
+            "url": "https://github.com/launchbynttdata/lcaf-template-terragrunt.git",
+            "tag": "1.0.0",
+        },
+        "sources": {
+            "service": {
+                "url": "https://github.com/launchbynttdata/tf-aws-module_collection-codepipeline.git",
+                "tag": "1.0.2",
+            },
+            "pipeline": {
+                "url": "https://github.com/launchbynttdata/tf-aws-module_collection-codepipeline.git",
+                "tag": "1.0.2",
+            },
+            "webhook": {
+                "url": "https://github.com/launchbynttdata/tf-aws-module_reference-bulk_lambda_function.git",
+                "tag": "1.1.0",
+            },
+        },
+        "platform": {
+            "service": {
+                "root": {
+                    "us-east-2": {
+                        "000": {
+                            "properties_file": "./platform/service/root/us-east-2/000/terraform.tfvars",
+                            "additional_files": {
+                                "root_file.txt": "./root_file.txt",
+                                "renamed_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
+                                "environment_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
+                                "nested_rename/renamed_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
+                            },
+                        }
+                    }
+                }
+            },
+            "pipeline": {
+                "pipeline-provider": {
+                    "root": {
+                        "us-east-2": {
+                            "000": {
+                                "properties_file": "./platform/pipeline/pipeline-provider/root/us-east-2/000/terraform.tfvars"
+                            }
+                        }
+                    }
+                },
+                "webhook-provider": {
+                    "root": {
+                        "us-east-2": {
+                            "000": {
+                                "properties_file": "./platform/pipeline/webhook-provider/root/us-east-2/000/terraform.tfvars"
+                            }
+                        }
+                    }
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture(scope="class")
+def launch_service_directory(launch_config_file_contents):
+    old_work_dir = os.getcwd()
+    with tempfile.TemporaryDirectory() as work_dir:
+        work_path = Path(work_dir)
+        work_path.joinpath(".launch_config").write_text(
+            json.dumps(launch_config_file_contents)
+        )
+        work_path.joinpath("root_file.txt").write_text("root file")
+        environment_file = (
+            work_path.joinpath("platform")
+            .joinpath("service")
+            .joinpath("root")
+            .joinpath("us-east-2")
+            .joinpath("000")
+            .joinpath("environment_file.txt")
+        )
+        environment_file.parent.mkdir(parents=True, exist_ok=False)
+        environment_file.write_text("environment file")
+        os.chdir(work_dir)
+        yield work_path
+    os.chdir(old_work_dir)
+
+
+@pytest.fixture(scope="class")
+def built_dir(launch_service_directory, launch_config_file_contents):
+    config = launch_config_file_contents[PLATFORM_SRC_DIR_PATH]
+    target_dir = launch_service_directory.joinpath(BUILD_TEMP_DIR_PATH).joinpath(
+        Path.cwd().name
+    )
+    copy_additional_files(platform_config=config, target_dir=target_dir, dry_run=False)
+    yield launch_service_directory
+
+
+class TestCopyAdditionalFiles:
+    def test_additional_environment_file_lands_in_environment(self, built_dir):
+        """The default use case, in which we copy a file with a given numbered environment into the build structure as-is."""
+        build_path = built_dir.joinpath(BUILD_TEMP_DIR_PATH).joinpath(Path.cwd().name)
+        expected_environment_file_path = build_path.joinpath(
+            "platform/service/root/us-east-2/000/environment_file.txt"
+        )
+        assert expected_environment_file_path.exists()
+        assert expected_environment_file_path.is_file()
+        assert expected_environment_file_path.read_text() == "environment file"
+
+    def test_copy_additional_file_allows_rename(self, built_dir):
+        """Copying files allows for a rename of the file by adjusting the key in the platform config."""
+        build_path = built_dir.joinpath(BUILD_TEMP_DIR_PATH).joinpath(Path.cwd().name)
+        expected_renamed_file_path = build_path.joinpath(
+            "platform/service/root/us-east-2/000/renamed_file.txt"
+        )
+        assert expected_renamed_file_path.exists()
+        assert expected_renamed_file_path.is_file()
+        assert expected_renamed_file_path.read_text() == "environment file"
+
+    def test_copy_additional_file_nested_directory(self, built_dir):
+        """Copying files allows for nesting files in arbitrary subdirectories by putting the path in the key."""
+        build_path = built_dir.joinpath(BUILD_TEMP_DIR_PATH).joinpath(Path.cwd().name)
+        expected_nested_file_path = build_path.joinpath(
+            "platform/service/root/us-east-2/000/nested_rename/renamed_file.txt"
+        )
+        assert expected_nested_file_path.exists()
+        assert expected_nested_file_path.is_file()
+        assert expected_nested_file_path.read_text() == "environment file"
+
+    def test_copy_additional_file_from_root(self, built_dir):
+        """Allows for copying a shared file located in the root of the repository into the numbered environment."""
+        build_path = built_dir.joinpath(BUILD_TEMP_DIR_PATH).joinpath(Path.cwd().name)
+        expected_root_file_path = build_path.joinpath(
+            "platform/service/root/us-east-2/000/root_file.txt"
+        )
+        assert expected_root_file_path.exists()
+        assert expected_root_file_path.is_file()
+        assert expected_root_file_path.read_text() == "root file"

--- a/test/unit/lib/service/template/functions/test_copy_additional_files.py
+++ b/test/unit/lib/service/template/functions/test_copy_additional_files.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from launch.config.common import BUILD_TEMP_DIR_PATH, PLATFORM_SRC_DIR_PATH
-from launch.lib.service.template.functions import copy_additional_files
+from launch.lib.service.template.launchconfig import LaunchConfigTemplate
 
 
 @pytest.fixture(scope="class")
@@ -104,7 +104,18 @@ def built_dir(launch_service_directory, launch_config_file_contents):
     target_dir = launch_service_directory.joinpath(BUILD_TEMP_DIR_PATH).joinpath(
         Path.cwd().name
     )
-    copy_additional_files(platform_config=config, target_dir=target_dir, dry_run=False)
+    LaunchConfigTemplate(dry_run=False).copy_additional_files(
+        value=config["service"]["root"]["us-east-2"]["000"],
+        current_path=(
+            target_dir.joinpath("platform")
+            .joinpath("service")
+            .joinpath("root")
+            .joinpath("us-east-2")
+            .joinpath("000")
+        ),
+        repo_base=launch_service_directory,
+        dest_base=target_dir,
+    )
     yield launch_service_directory
 
 


### PR DESCRIPTION
Allows for distribution of arbitrary files into built directories when utilizing `launch service build` / `launch terragrunt --generate`. I found evidence that this was a desired but unimplemented feature, and I need this functionality to work in order to deploy pipelines as a service for other consumers.

File copy behaviors are best illustrated through this example, showing a hypothetical service configuration from a `.launch_config` file:

```json
"service": {
    "root": {
        "us-east-2": {
            "000": {
                "properties_file": "./platform/service/root/us-east-2/000/terraform.tfvars",
                "additional_files": {
                    "root_file.txt": "./root_file.txt",
                    "renamed_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
                    "environment_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
                    "nested_rename/renamed_file.txt": "./platform/service/root/us-east-2/000/environment_file.txt",
                },
            }
        }
    }
},
```

The `additional_files` structure above will perform the following operations:

- A file from the root of the repository called `root_file.txt` will be copied into the built directories at `.launch/build/<repo name>/platform/service/root/us-east-2/000/root_file.txt`. This allows you to share common files into multiple numbered environments.
- A source file from the numbered environment directory called `environment_file.txt` will be:
    - Copied as-is, illustrating how single files can be sourced from a numbered environment directory and placed in the built numbered environment (the "default" use case).
    - Copied to the built directories' numbered environment and renamed to `renamed_file.txt`, illustrating how files can be renamed when copied.
    - Copied to a subfolder in the built numbered environment, illustrating that by adding path information to the file's key, the path is reflected in the copied file.
    
Additionally, this PR contains a small fix to the `process_template` function to prevent a folder called `additional_files/` from being created within the built numbered environment. Target file paths are determined based on the key in the configuration file.
