### PR TITLE
Fix/guard environment mutations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.11.0"
+version = "0.11.1"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/config/common.py
+++ b/src/launch/config/common.py
@@ -1,4 +1,4 @@
-from launch.env import override_default
+from launch.env import get_bool_env_var, override_default
 
 BUILD_DEPENDENCIES_PATH = override_default(
     key_name="BUILD_DEPENDENCIES_PATH",
@@ -19,6 +19,8 @@ DOCKER_FILE_NAME = override_default(
     key_name="DOCKER_FILE_NAME",
     default="Dockerfile",
 )
+
+IS_PIPELINE = get_bool_env_var(env_var_name="IS_PIPELINE", default_value=False)
 
 PLATFORM_SRC_DIR_PATH = override_default(
     key_name="PLATFORM_SRC_DIR_PATH",

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.11.0"
+VERSION = "0.11.1"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/src/launch/lib/automation/environment/functions.py
+++ b/src/launch/lib/automation/environment/functions.py
@@ -57,29 +57,30 @@ def set_netrc(
         click.echo(
             f"Not running in a pipeline, skipping setting {netrc_path} variables."
         )
-    else:
-        click.echo(f"Setting {netrc_path} variables")
-        if netrc_path.exists():
+        return
+
+    click.echo(f"Setting {netrc_path} variables")
+    if netrc_path.exists():
+        click.secho(
+            f"{netrc_path} already exists, skipping...",
+            fg="yellow",
+        )
+        return
+    try:
+        if dry_run:
             click.secho(
-                f"{netrc_path} already exists, skipping...",
+                f"[DRYRUN] Would have written to {netrc_path}: {machine=} {login=}",
                 fg="yellow",
             )
-            return
-        try:
-            if dry_run:
-                click.secho(
-                    f"[DRYRUN] Would have written to {netrc_path}: {machine=} {login=}",
-                    fg="yellow",
-                )
-            else:
-                with open(netrc_path, "x") as file:
-                    file.write(f"machine {machine}\n")
-                    file.write(f"login {login}\n")
-                    file.write(f"password {password}\n")
+        else:
+            with open(netrc_path, "x") as file:
+                file.write(f"machine {machine}\n")
+                file.write(f"login {login}\n")
+                file.write(f"password {password}\n")
 
-                os.chmod(netrc_path, 0o600)
-        except Exception as e:
-            raise RuntimeError(f"An error occurred: {str(e)}")
+            os.chmod(netrc_path, 0o600)
+    except Exception as e:
+        raise RuntimeError(f"An error occurred: {str(e)}")
 
 
 # This can be deprecated when we refactor the lambdas and no longer use shell scipts in the build process

--- a/src/launch/lib/automation/environment/functions.py
+++ b/src/launch/lib/automation/environment/functions.py
@@ -72,7 +72,7 @@ def set_netrc(
                     fg="yellow",
                 )
             else:
-                with open(netrc_path, "a") as file:
+                with open(netrc_path, "x") as file:
                     file.write(f"machine {machine}\n")
                     file.write(f"login {login}\n")
                     file.write(f"password {password}\n")

--- a/test/unit/lib/automation/environment/functions/test_set_netrc.py
+++ b/test/unit/lib/automation/environment/functions/test_set_netrc.py
@@ -1,66 +1,100 @@
+import importlib
 import os
+import tempfile
 from pathlib import Path
 from unittest.mock import mock_open
 
 import pytest
+from faker import Faker
 
-from launch.lib.automation.environment.functions import set_netrc
+from launch.lib.automation.environment import functions
+
+fake = Faker()
 
 
 @pytest.fixture
-def netrc_path():
-    return Path("/path/to/target/.netrc")
+def set_pipeline(mocker):
+    mocker.patch.object(functions, "IS_PIPELINE", True)
+    yield
 
 
-def test_set_netrc_success(mocker, netrc_path):
-    # Mock the open function and os.chmod call
-    mock_file_open = mock_open()
-    mocker.patch("builtins.open", mock_file_open)
-    mock_chmod = mocker.patch("os.chmod")
+@pytest.fixture
+def set_no_pipeline(mocker):
+    mocker.patch.object(functions, "IS_PIPELINE", False)
+    yield
 
-    set_netrc(
-        "password123", "example.com", "username", netrc_path=netrc_path, dry_run=False
+
+@pytest.fixture
+def no_netrc():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir).joinpath(".netrc")
+
+
+@pytest.fixture
+def existing_netrc():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        netrc_path = Path(temp_dir).joinpath(".netrc")
+        netrc_path.write_text(
+            "machine example.com\nlogin username\npassword password123\n"
+        )
+        yield netrc_path
+
+
+def test_pipeline_environment_variable_skips_netrc(mocker, no_netrc, set_no_pipeline):
+    click_echo = mocker.patch("click.echo")
+
+    functions.set_netrc("password123", netrc_path=no_netrc, dry_run=False)
+    click_echo.assert_called_once_with(
+        f"Not running in a pipeline, skipping setting {no_netrc} variables."
     )
 
-    # Check if file was written correctly
-    mock_file_open.assert_called_once_with(netrc_path, "a")
-    handle = mock_file_open()
-    handle.write.assert_has_calls(
-        [
-            mocker.call("machine example.com\n"),
-            mocker.call("login username\n"),
-            mocker.call("password password123\n"),
-        ]
+
+def test_set_netrc_success(no_netrc, set_pipeline):
+    fake_username = fake.user_name()
+    fake_password = fake.password()
+    fake_domain = fake.domain_name()
+
+    """A successful netrc write and chmod."""
+    functions.set_netrc(
+        password=fake_password,
+        machine=fake_domain,
+        login=fake_username,
+        netrc_path=no_netrc,
+        dry_run=False,
     )
 
-    # Check if os.chmod was called correctly
-    mock_chmod.assert_called_once_with(netrc_path, 0o600)
+    assert no_netrc.exists()
+    netrc_contents = no_netrc.read_text()
+    assert (
+        f"machine {fake_domain}\nlogin {fake_username}\npassword {fake_password}\n"
+        in netrc_contents
+    )
+    assert no_netrc.stat().st_mode & 0o777 == 0o600
 
 
-def test_set_netrc_exception_during_write(mocker, netrc_path):
-    # Mock open to raise an exception
+def test_set_netrc_exception_during_write(mocker, no_netrc, set_pipeline):
+    """Simulates an unsuccessful write."""
     mocker.patch("builtins.open", side_effect=IOError("File write error"))
 
     with pytest.raises(RuntimeError, match="An error occurred"):
-        set_netrc(
+        functions.set_netrc(
             "password123",
             "example.com",
             "username",
-            netrc_path=netrc_path,
+            netrc_path=no_netrc,
             dry_run=False,
         )
 
 
-def test_set_netrc_exception_during_chmod(mocker, netrc_path):
-    # Mock the open function and os.chmod to raise an exception
-    mocker.patch("builtins.open", mock_open())
+def test_set_netrc_exception_during_chmod(mocker, no_netrc, set_pipeline):
+    """Simulates a successful write but unsuccessful chmod."""
     mocker.patch("os.chmod", side_effect=OSError("Permission error"))
 
     with pytest.raises(RuntimeError, match="An error occurred"):
-        set_netrc(
+        functions.set_netrc(
             "password123",
             "example.com",
             "username",
-            netrc_path=netrc_path,
+            netrc_path=no_netrc,
             dry_run=False,
         )


### PR DESCRIPTION
This change will prevent launch-cli from modifying a .netrc file in-place by utilizing the `IS_PIPELINE` environment variable that we use in our Makefiles. Previously, this tool made modifications to the .netrc file that may exist on developer machines, which was causing unexpected behavior when end users were expecting to use a different credential path (git-credential-manager) for authenticating with alternate GitHub organizations.

If `IS_PIPELINE` is set (this should only be the case in the build containers), using `launch service build` or `launch terragrunt` commands will create the .netrc file in the home directory for auth with the SCM provider. I've changed the `mode` to `x` for exclusive creation to reflect how we're using this logic.

Additionally, this revamps unit tests around .netrc to create a real .netrc in a temporary path and fully validate both the contents of the file written match the expected values, and the permissions on the file reflect what we expect, rather than just mocking those operations.

Special thanks to @aarti-joshi-nttd for helping track this one down.