### PR TITLE
Feature/GitHub commit status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.11.1"
+version = "0.12.0"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/cli/github/__init__.py
+++ b/src/launch/cli/github/__init__.py
@@ -2,6 +2,7 @@ import click
 
 from .access import access_group
 from .auth import auth_group
+from .commit import commit_group
 from .hooks import hooks_group
 from .repo import repo_group
 from .version import version_group
@@ -17,3 +18,4 @@ github_group.add_command(hooks_group)
 github_group.add_command(version_group)
 github_group.add_command(repo_group)
 github_group.add_command(auth_group)
+github_group.add_command(commit_group)

--- a/src/launch/cli/github/commit/__init__.py
+++ b/src/launch/cli/github/commit/__init__.py
@@ -5,7 +5,7 @@ from .status import status_group
 
 @click.group(name="commit")
 def commit_group():
-    """Command family for dealing with GitHub webhooks."""
+    """Command family for dealing with GitHub commits, including commit status."""
 
 
 commit_group.add_command(status_group)

--- a/src/launch/cli/github/commit/__init__.py
+++ b/src/launch/cli/github/commit/__init__.py
@@ -1,0 +1,11 @@
+import click
+
+from .status import status_group
+
+
+@click.group(name="commit")
+def commit_group():
+    """Command family for dealing with GitHub webhooks."""
+
+
+commit_group.add_command(status_group)

--- a/src/launch/cli/github/commit/status.py
+++ b/src/launch/cli/github/commit/status.py
@@ -33,12 +33,12 @@ def get(organization: str, repository_name: str, commit_hash: str, context: str)
         commit_sha=commit_hash,
         context=context,
     )
-    if status:
-        click.echo(status.state)
-    else:
+    if not status:
         click.echo(
             f"No status found for {commit_hash} in {organization}/{repository_name}."
         )
+        return
+    click.echo(status.state)
 
 
 @click.command("set")

--- a/src/launch/cli/github/commit/status.py
+++ b/src/launch/cli/github/commit/status.py
@@ -33,7 +33,12 @@ def get(organization: str, repository_name: str, commit_hash: str, context: str)
         commit_sha=commit_hash,
         context=context,
     )
-    click.echo(status.state)
+    if status:
+        click.echo(status.state)
+    else:
+        click.echo(
+            f"No status found for {commit_hash} in {organization}/{repository_name}."
+        )
 
 
 @click.command("set")

--- a/src/launch/cli/github/commit/status.py
+++ b/src/launch/cli/github/commit/status.py
@@ -1,0 +1,102 @@
+import click
+
+from launch.config.github import GITHUB_ORG_NAME
+from launch.lib.github.auth import get_github_instance
+from launch.lib.github.commit_status import (
+    CommitStatusState,
+    CommitStatusUpdatePayload,
+    get_commit_status,
+    set_commit_status,
+)
+
+
+@click.command("get")
+@click.option(
+    "--organization",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization containing your repository. Defaults to the {GITHUB_ORG_NAME} organization.",
+)
+@click.option(
+    "--repository-name", required=True, help="Name of the repository to be updated."
+)
+@click.option("--commit-hash", required=True, help="Full SHA1 hash of a Git commit.")
+@click.option(
+    "--context",
+    default="",
+    help="A string label to differentiate this status from the status of other systems.",
+)
+def get(organization: str, repository_name: str, commit_hash: str, context: str):
+    status = get_commit_status(
+        get_github_instance(),
+        repo_name=repository_name,
+        repo_org=organization,
+        commit_sha=commit_hash,
+        context=context,
+    )
+    click.echo(status.state)
+
+
+@click.command("set")
+@click.option(
+    "--organization",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization containing your repository. Defaults to the {GITHUB_ORG_NAME} organization.",
+)
+@click.option(
+    "--repository-name", required=True, help="Name of the repository to be updated."
+)
+@click.option("--commit-hash", required=True, help="Full SHA1 hash of a Git commit.")
+@click.option(
+    "--target-url",
+    default="",
+    help="The URL to link when setting a commit status message.",
+)
+@click.option(
+    "--description",
+    default="",
+    help="A short message to associate with the commit status.",
+)
+@click.option(
+    "--context",
+    default="",
+    help="A string label to differentiate this status from the status of other systems.",
+)
+@click.option(
+    "--status",
+    required=True,
+    type=click.Choice(
+        choices=[e.value for e in CommitStatusState], case_sensitive=False
+    ),
+    help="The status to set on the commit.",
+)
+def set(
+    organization: str,
+    repository_name: str,
+    commit_hash: str,
+    status: CommitStatusState,
+    target_url: str,
+    description: str,
+    context: str,
+):
+    payload = CommitStatusUpdatePayload(
+        state=CommitStatusState(status),
+        target_url=target_url,
+        description=description,
+        context=context,
+    )
+    set_commit_status(
+        git_connection=get_github_instance(),
+        repo_name=repository_name,
+        repo_org=organization,
+        commit_sha=commit_hash,
+        payload=payload,
+    )
+
+
+@click.group(name="status")
+def status_group():
+    """Command family for dealing with GitHub commit status."""
+
+
+status_group.add_command(get)
+status_group.add_command(set)

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.11.1"
+VERSION = "0.12.0"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/src/launch/lib/github/commit_status.py
+++ b/src/launch/lib/github/commit_status.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from github import Github
+from github.CommitStatus import CommitStatus
+
+
+class CommitStatusState(StrEnum):
+    error = "error"
+    failure = "failure"
+    pending = "pending"
+    success = "success"
+
+
+@dataclass
+class CommitStatusUpdatePayload:
+    state: CommitStatusState
+    target_url: str
+    description: str
+    context: str
+
+
+def get_commit_status(
+    git_connection: Github, repo_name: str, repo_org: str, commit_sha: str, context: str
+) -> CommitStatus | None:
+    repo = git_connection.get_repo(full_name_or_id=f"{repo_org}/{repo_name}")
+    commit = repo.get_commit(sha=commit_sha)
+    commit_statuses = commit.get_combined_status().statuses
+    filtered_by_context = list(filter(lambda x: x.context == context, commit_statuses))
+    if len(filtered_by_context) > 1:
+        raise RuntimeError(f"Too many filtered items! {filtered_by_context}")
+    elif len(filtered_by_context) == 1:
+        return filtered_by_context[0]
+    else:
+        return None
+
+
+def set_commit_status(
+    git_connection: Github,
+    repo_name: str,
+    repo_org: str,
+    commit_sha: str,
+    payload: CommitStatusUpdatePayload,
+) -> None:
+    repo = git_connection.get_repo(full_name_or_id=f"{repo_org}/{repo_name}")
+    commit = repo.get_commit(sha=commit_sha)
+    commit.create_status(
+        state=payload.state,
+        target_url=str(payload.target_url),
+        description=payload.description,
+        context=payload.context,
+    )

--- a/test/unit/lib/github/test_commit_status.py
+++ b/test/unit/lib/github/test_commit_status.py
@@ -100,11 +100,11 @@ def test_get_commit_status_no_context_match(
 
     expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
 
-    assert mocked_github["github_instance"].get_repo.called_once_with(
-        expected_repo_path
+    mocked_github["github_instance"].get_repo.assert_called_once_with(
+        full_name_or_id=expected_repo_path
     )
-    assert mocked_github["repo_instance"].called_once_with(
-        repo_and_commit_attributes["commit_sha"]
+    mocked_github["repo_instance"].get_commit.assert_called_once_with(
+        sha=repo_and_commit_attributes["commit_sha"]
     )
     assert mocked_github["commit_instance"].get_combined_status.called_once()
     assert found_status is None
@@ -128,13 +128,13 @@ def test_set_commit_status(mocker, mocked_github, repo_and_commit_attributes):
 
     expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
 
-    assert mocked_github["github_instance"].get_repo.called_once_with(
-        expected_repo_path
+    mocked_github["github_instance"].get_repo.assert_called_once_with(
+        full_name_or_id=expected_repo_path
     )
-    assert mocked_github["repo_instance"].called_once_with(
-        repo_and_commit_attributes["commit_sha"]
+    mocked_github["repo_instance"].get_commit.assert_called_once_with(
+        sha=repo_and_commit_attributes["commit_sha"]
     )
-    assert mocked_github["commit_instance"].create_status.called_once_with(
+    mocked_github["commit_instance"].create_status.assert_called_once_with(
         state=payload.state,
         target_url=str(payload.target_url),
         description=payload.description,

--- a/test/unit/lib/github/test_commit_status.py
+++ b/test/unit/lib/github/test_commit_status.py
@@ -78,7 +78,7 @@ def test_get_commit_status(
     mocked_github["repo_instance"].get_commit.assert_called_once_with(
         sha=repo_and_commit_attributes["commit_sha"]
     )
-    assert mocked_github["commit_instance"].get_combined_status.called_once()
+    mocked_github["commit_instance"].get_combined_status.assert_called_once()
     assert found_status.context == context_words["context_word"]
 
 
@@ -106,7 +106,7 @@ def test_get_commit_status_no_context_match(
     mocked_github["repo_instance"].get_commit.assert_called_once_with(
         sha=repo_and_commit_attributes["commit_sha"]
     )
-    assert mocked_github["commit_instance"].get_combined_status.called_once()
+    mocked_github["commit_instance"].get_combined_status.assert_called_once()
     assert found_status is None
 
 

--- a/test/unit/lib/github/test_commit_status.py
+++ b/test/unit/lib/github/test_commit_status.py
@@ -72,11 +72,11 @@ def test_get_commit_status(
 
     expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
 
-    assert mocked_github["github_instance"].get_repo.called_once_with(
-        expected_repo_path
+    mocked_github["github_instance"].get_repo.assert_called_once_with(
+        full_name_or_id=expected_repo_path
     )
-    assert mocked_github["repo_instance"].called_once_with(
-        repo_and_commit_attributes["commit_sha"]
+    mocked_github["repo_instance"].assert_called_once_with(
+        sha=repo_and_commit_attributes["commit_sha"]
     )
     assert mocked_github["commit_instance"].get_combined_status.called_once()
     assert found_status.context == context_words["context_word"]

--- a/test/unit/lib/github/test_commit_status.py
+++ b/test/unit/lib/github/test_commit_status.py
@@ -75,7 +75,7 @@ def test_get_commit_status(
     mocked_github["github_instance"].get_repo.assert_called_once_with(
         full_name_or_id=expected_repo_path
     )
-    mocked_github["repo_instance"].assert_called_once_with(
+    mocked_github["repo_instance"].get_commit.assert_called_once_with(
         sha=repo_and_commit_attributes["commit_sha"]
     )
     assert mocked_github["commit_instance"].get_combined_status.called_once()

--- a/test/unit/lib/github/test_commit_status.py
+++ b/test/unit/lib/github/test_commit_status.py
@@ -1,0 +1,142 @@
+import pytest
+from faker import Faker
+from github.CommitStatus import CommitStatus
+
+from launch.lib.github.commit_status import (
+    CommitStatusState,
+    CommitStatusUpdatePayload,
+    get_commit_status,
+    set_commit_status,
+)
+
+fake = Faker()
+
+
+@pytest.fixture()
+def context_words():
+    yield {
+        "context_word": fake.unique.word(),
+        "context_nonmatching_word": fake.unique.word(),
+    }
+
+
+@pytest.fixture
+def repo_and_commit_attributes():
+    yield {
+        "org_name": fake.unique.word(),
+        "repo_name": fake.unique.word(),
+        "commit_sha": fake.sha1(),
+    }
+
+
+@pytest.fixture
+def mocked_github(mocker):
+    github_instance = mocker.MagicMock()
+    repo_instance = mocker.MagicMock()
+    commit_instance = mocker.MagicMock()
+    combined_status_instance = mocker.MagicMock()
+
+    github_instance.get_repo.return_value = repo_instance
+    repo_instance.get_commit.return_value = commit_instance
+    commit_instance.get_combined_status.return_value = combined_status_instance
+
+    yield {
+        "github_instance": github_instance,
+        "repo_instance": repo_instance,
+        "commit_instance": commit_instance,
+        "combined_status_instance": combined_status_instance,
+    }
+
+
+def test_get_commit_status(
+    mocker, mocked_github, repo_and_commit_attributes, context_words
+):
+    matching_context_status = mocker.MagicMock(spec=CommitStatus)
+    matching_context_status.context = context_words["context_word"]
+
+    nonmatching_context_status = mocker.MagicMock(spec=CommitStatus)
+    nonmatching_context_status.context = context_words["context_nonmatching_word"]
+
+    mocked_github["combined_status_instance"].statuses = [
+        matching_context_status,
+        nonmatching_context_status,
+    ]
+
+    found_status = get_commit_status(
+        git_connection=mocked_github["github_instance"],
+        repo_name=repo_and_commit_attributes["repo_name"],
+        repo_org=repo_and_commit_attributes["org_name"],
+        commit_sha=repo_and_commit_attributes["commit_sha"],
+        context=context_words["context_word"],
+    )
+
+    expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
+
+    assert mocked_github["github_instance"].get_repo.called_once_with(
+        expected_repo_path
+    )
+    assert mocked_github["repo_instance"].called_once_with(
+        repo_and_commit_attributes["commit_sha"]
+    )
+    assert mocked_github["commit_instance"].get_combined_status.called_once()
+    assert found_status.context == context_words["context_word"]
+
+
+def test_get_commit_status_no_context_match(
+    mocker, mocked_github, repo_and_commit_attributes, context_words
+):
+    nonmatching_context_status = mocker.MagicMock(spec=CommitStatus)
+    nonmatching_context_status.context = context_words["context_nonmatching_word"]
+
+    mocked_github["combined_status_instance"].statuses = [nonmatching_context_status]
+
+    found_status = get_commit_status(
+        git_connection=mocked_github["github_instance"],
+        repo_name=repo_and_commit_attributes["repo_name"],
+        repo_org=repo_and_commit_attributes["org_name"],
+        commit_sha=repo_and_commit_attributes["commit_sha"],
+        context=context_words["context_word"],
+    )
+
+    expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
+
+    assert mocked_github["github_instance"].get_repo.called_once_with(
+        expected_repo_path
+    )
+    assert mocked_github["repo_instance"].called_once_with(
+        repo_and_commit_attributes["commit_sha"]
+    )
+    assert mocked_github["commit_instance"].get_combined_status.called_once()
+    assert found_status is None
+
+
+def test_set_commit_status(mocker, mocked_github, repo_and_commit_attributes):
+    payload = CommitStatusUpdatePayload(
+        state=CommitStatusState.success,
+        target_url=fake.url(),
+        description=fake.sentence(),
+        context=fake.word(),
+    )
+
+    set_commit_status(
+        git_connection=mocked_github["github_instance"],
+        repo_name=repo_and_commit_attributes["repo_name"],
+        repo_org=repo_and_commit_attributes["org_name"],
+        commit_sha=repo_and_commit_attributes["commit_sha"],
+        payload=payload,
+    )
+
+    expected_repo_path = f"{repo_and_commit_attributes['org_name']}/{repo_and_commit_attributes['repo_name']}"
+
+    assert mocked_github["github_instance"].get_repo.called_once_with(
+        expected_repo_path
+    )
+    assert mocked_github["repo_instance"].called_once_with(
+        repo_and_commit_attributes["commit_sha"]
+    )
+    assert mocked_github["commit_instance"].create_status.called_once_with(
+        state=payload.state,
+        target_url=str(payload.target_url),
+        description=payload.description,
+        context=payload.context,
+    )


### PR DESCRIPTION
This PR adds functionality to retrieve and set [GitHub commit statuses](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks#types-of-status-checks-on-github) from the CLI or within a pipeline. 

```sh
# launch github commit status set --help                                                                                                                                              Usage: launch github commit status set [OPTIONS]

Options:
  --organization TEXT             GitHub organization containing your
                                  repository. Defaults to the launchbynttdata
                                  organization.
  --repository-name TEXT          Name of the repository to be updated.
                                  [required]
  --commit-hash TEXT              Full SHA1 hash of a Git commit.  [required]
  --target-url TEXT               The URL to link when setting a commit status
                                  message.
  --description TEXT              A short message to associate with the commit
                                  status.
  --context TEXT                  A string label to differentiate this status
                                  from the status of other systems.
  --status [error|failure|pending|success]
                                  The status to set on the commit.  [required]
  --help                          Show this message and exit.

# launch github commit status get --help
Usage: launch github commit status get [OPTIONS]

Options:
  --organization TEXT     GitHub organization containing your repository.
                          Defaults to the launchbynttdata organization.
  --repository-name TEXT  Name of the repository to be updated.  [required]
  --commit-hash TEXT      Full SHA1 hash of a Git commit.  [required]
  --context TEXT          A string label to differentiate this status from the
                          status of other systems.
  --help                  Show this message and exit.
```

```sh
# Set a "pending" status on a commit to indicate a CI run is in progress. 
# The "context" and "description" are displayed on the PR page, and the 
# "target URL" is linked through the "Details" button, allowing a user
# to link directly into a CI pipeline run:
launch github commit status set \
    --repository-name "tf-aws-module_primitive-api_gateway_v2" \
    --commit-hash "a87b67e7040ec3fc48c5e3c20f6f6f42b611c1b8" \
    --status pending \
    --target-url "https://launch.nttdata.com" \
    --context "ci/shared-aws-terraform-pipeline" \
    --description "Build in progress..."
```

<img width="914" alt="image" src="https://github.com/user-attachments/assets/1f28897e-0d41-42df-8c04-c0ff656901aa">

---

```sh
# Set a "complete" status on a commit to allow the merge
# to proceed.
launch github commit status set \
    --repository-name "tf-aws-module_primitive-api_gateway_v2" \
    --commit-hash "a87b67e7040ec3fc48c5e3c20f6f6f42b611c1b8" \
    --status complete \
    --target-url "https://launch.nttdata.com" \
    --context "ci/shared-aws-terraform-pipeline" \
    --description "Build succeeded."
```

<img width="912" alt="image" src="https://github.com/user-attachments/assets/eaec876c-a99a-47fb-97ba-7973569f64db">

---

```sh
# Retrieve a commit status
launch github commit status get \
    --repository-name "tf-aws-module_primitive-api_gateway_v2" \
    --commit-hash "a87b67e7040ec3fc48c5e3c20f6f6f42b611c1b8" \
    --context "ci/shared-aws-terraform-pipeline"
success
```


