### PR TITLE
Add commands to verify organization membership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.12.0"
+version = "0.13.0"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/cli/github/access/__init__.py
+++ b/src/launch/cli/github/access/__init__.py
@@ -1,6 +1,6 @@
 import click
 
-from .commands import set_default
+from .commands import check_pr_organization, check_user_organization, set_default
 
 
 @click.group(name="access")
@@ -9,3 +9,5 @@ def access_group():
 
 
 access_group.add_command(set_default)
+access_group.add_command(check_user_organization)
+access_group.add_command(check_pr_organization)

--- a/src/launch/cli/github/access/commands.py
+++ b/src/launch/cli/github/access/commands.py
@@ -91,15 +91,15 @@ def check_user_organization(
     organization: str, user_id: int = None, user_name: str = None
 ):
     """Checks if a user is a member of an organization."""
-    g = get_github_instance()
-    org = g.get_organization(login=organization)
-
     if user_id is None and user_name is None:
         click.secho("Either a --user-id or --user-name must be provided.")
         exit(-1)
     if not user_id is None and not user_name is None:
         click.secho("Only one of --user-id or --user-name can be provided.")
         exit(-2)
+
+    g = get_github_instance()
+    org = g.get_organization(login=organization)
 
     if user_id:
         user = g.get_user_by_id(user_id)

--- a/src/launch/cli/github/access/commands.py
+++ b/src/launch/cli/github/access/commands.py
@@ -69,3 +69,78 @@ def set_default(organization: str, repository_name: str, dry_run: bool):
     if specific_admin_team:
         grant_admin(team=specific_admin_team, repository=repository, dry_run=dry_run)
     configure_default_branch_protection(repository=repository, dry_run=dry_run)
+
+
+@click.command("check-user")
+@click.option(
+    "--user-id",
+    type=click.INT,
+    help="The user ID of the user to check. Mutually exclusive with --user-name.",
+)
+@click.option(
+    "--user-name",
+    type=click.STRING,
+    help="The user name of the user to check. Mutually exclusive with --user-id.",
+)
+@click.option(
+    "--organization",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization to verify the user's membership. Defaults to the {GITHUB_ORG_NAME} organization.",
+)
+def check_user_organization(
+    organization: str, user_id: int = None, user_name: str = None
+):
+    """Checks if a user is a member of an organization."""
+    g = get_github_instance()
+    org = g.get_organization(login=organization)
+
+    if user_id is None and user_name is None:
+        click.secho("Either a --user-id or --user-name must be provided.")
+        exit(-1)
+    if not user_id is None and not user_name is None:
+        click.secho("Only one of --user-id or --user-name can be provided.")
+        exit(-2)
+
+    if user_id:
+        user = g.get_user_by_id(user_id)
+    else:
+        user = g.get_user(login=user_name)
+
+    if org.has_in_members(user):
+        click.echo(f"{user.login} is a member of {org.login}")
+    else:
+        click.echo(f"{user.login} is not a member of {org.login}")
+        exit(1)
+
+
+@click.command("check-pr")
+@click.option(
+    "--repository",
+    envvar="GIT_REPO",
+    type=click.STRING,
+    required=True,
+    help="The Repository where the pull request was opened.",
+)
+@click.option(
+    "--pr-number",
+    type=click.INT,
+    required=True,
+    help="The ID of the pull request to check.",
+)
+@click.option(
+    "--organization",
+    default=GITHUB_ORG_NAME,
+    help=f"GitHub organization to verify the user's membership. Defaults to the {GITHUB_ORG_NAME} organization.",
+)
+def check_pr_organization(repository: str, pr_number: int, organization: str):
+    """Checks if a pull request originated from inside the organization or from outside."""
+    g = get_github_instance()
+    org = g.get_organization(login=organization)
+    pr = org.get_repo(repository).get_pull(pr_number)
+    user = pr.user
+
+    if org.has_in_members(user):
+        click.echo(f"{user.login} is a member of {org.login}")
+    else:
+        click.echo(f"{user.login} is not a member of {org.login}")
+        exit(1)

--- a/src/launch/constants/version.py
+++ b/src/launch/constants/version.py
@@ -1,5 +1,5 @@
 from semver import Version
 
-VERSION = "0.12.0"
+VERSION = "0.13.0"
 
 SEMANTIC_VERSION = Version.parse(VERSION)

--- a/test/unit/cli/github/test_check_org_membership.py
+++ b/test/unit/cli/github/test_check_org_membership.py
@@ -1,0 +1,151 @@
+import pytest
+
+from launch.cli.github.access import commands
+
+
+@pytest.fixture
+def mocked_github(mocker):
+    mocked_gh = mocker.MagicMock()
+    mocked_org = mocker.MagicMock()
+    mocked_repo = mocker.MagicMock()
+    mocked_pr = mocker.MagicMock()
+    mocked_user = mocker.MagicMock()
+
+    mocked_org.get_repo.return_value = mocked_repo
+    mocked_repo.get_pull.return_value = mocked_pr
+    mocked_pr.user = mocked_user
+    mocked_gh.get_organization.return_value = mocked_org
+    mocked_gh.get_user_by_id.return_value = mocked_user
+    mocked_gh.get_user.return_value = mocked_user
+
+    mocker.patch.object(commands, "get_github_instance", return_value=mocked_gh)
+
+    yield mocked_gh, mocked_org, mocked_repo, mocked_pr, mocked_user
+
+
+@pytest.fixture
+def mocked_github_member(mocker, mocked_github):
+    mocked_gh, mocked_org, mocked_repo, mocked_pr, mocked_user = mocked_github
+    mocked_org.has_in_members = mocker.MagicMock(return_value=True)
+    yield mocked_gh, mocked_org, mocked_repo, mocked_pr, mocked_user
+
+
+@pytest.fixture
+def mocked_github_nonmember(mocker, mocked_github):
+    mocked_gh, mocked_org, mocked_repo, mocked_pr, mocked_user = mocked_github
+    mocked_org.has_in_members = mocker.MagicMock(return_value=False)
+    yield mocked_gh, mocked_org, mocked_repo, mocked_pr, mocked_user
+
+
+class TestUserOrganization:
+    def test_check_user_organization_fails_with_missing_params(self, cli_runner):
+        result = cli_runner.invoke(
+            commands.check_user_organization,
+            [],
+        )
+        assert result.exception
+        assert result.exit_code != 0
+        assert "Either a --user-id or --user-name must be provided." in result.output
+
+    def test_check_user_organization_by_id_ok(self, cli_runner, mocked_github_member):
+        result = cli_runner.invoke(
+            commands.check_user_organization,
+            ["--organization", "phony_org", "--user-id", "12345"],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+
+    def test_check_user_organzation_by_name_ok(self, cli_runner, mocked_github_member):
+        result = cli_runner.invoke(
+            commands.check_user_organization,
+            ["--organization", "phony_org", "--user-name", "phony_user"],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+
+    def test_check_user_organization_by_id_fails_nonzero(
+        self, cli_runner, mocked_github_nonmember
+    ):
+        (
+            mocked_gh,
+            mocked_org,
+            mocked_repo,
+            mocked_pr,
+            mocked_user,
+        ) = mocked_github_nonmember
+
+        result = cli_runner.invoke(
+            commands.check_user_organization,
+            ["--organization", "phony_org", "--user-id", "12345"],
+        )
+        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        assert result.exception
+        assert result.exit_code != 0
+
+    def test_check_user_organization_by_name_fails_nonzero(
+        self, cli_runner, mocked_github_nonmember
+    ):
+        (
+            mocked_gh,
+            mocked_org,
+            mocked_repo,
+            mocked_pr,
+            mocked_user,
+        ) = mocked_github_nonmember
+
+        result = cli_runner.invoke(
+            commands.check_user_organization,
+            ["--organization", "phony_org", "--user-name", "phony_user"],
+        )
+        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        assert result.exception
+        assert result.exit_code != 0
+
+
+class TestPullRequestOrganization:
+    def test_check_pr_organization_fails_with_missing_repository_param(
+        self, cli_runner
+    ):
+        result = cli_runner.invoke(
+            commands.check_pr_organization,
+            [],
+        )
+        assert result.exception
+        assert result.exit_code != 0
+        assert "Missing option '--repository'" in result.output
+
+    def test_check_pr_organization_fails_with_missing_pr_number_param(self, cli_runner):
+        result = cli_runner.invoke(
+            commands.check_pr_organization,
+            ["--repository", "phony_repo"],
+        )
+        assert result.exception
+        assert result.exit_code != 0
+        assert "Missing option '--pr-number'" in result.output
+
+    def test_check_pr_organization_ok(self, cli_runner, mocked_github_member):
+        result = cli_runner.invoke(
+            commands.check_pr_organization,
+            ["--repository", "phony_repo", "--pr-number", "12345"],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+
+    def test_check_pr_organization_fails_nonzero(
+        self, cli_runner, mocked_github_nonmember
+    ):
+        (
+            mocked_gh,
+            mocked_org,
+            mocked_repo,
+            mocked_pr,
+            mocked_user,
+        ) = mocked_github_nonmember
+
+        result = cli_runner.invoke(
+            commands.check_pr_organization,
+            ["--repository", "phony_repo", "--pr-number", "12345"],
+        )
+        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        assert result.exception
+        assert result.exit_code != 0

--- a/test/unit/cli/github/test_check_org_membership.py
+++ b/test/unit/cli/github/test_check_org_membership.py
@@ -78,7 +78,7 @@ class TestUserOrganization:
             commands.check_user_organization,
             ["--organization", "phony_org", "--user-id", "12345"],
         )
-        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        mocked_org.has_in_members.assert_called_once_with(mocked_user)
         assert result.exception
         assert result.exit_code != 0
 
@@ -97,7 +97,7 @@ class TestUserOrganization:
             commands.check_user_organization,
             ["--organization", "phony_org", "--user-name", "phony_user"],
         )
-        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        mocked_org.has_in_members.assert_called_once_with(mocked_user)
         assert result.exception
         assert result.exit_code != 0
 
@@ -146,6 +146,6 @@ class TestPullRequestOrganization:
             commands.check_pr_organization,
             ["--repository", "phony_repo", "--pr-number", "12345"],
         )
-        assert mocked_org.has_in_members.called_once_with(mocked_user)
+        mocked_org.has_in_members.assert_called_once_with(mocked_user)
         assert result.exception
         assert result.exit_code != 0


### PR DESCRIPTION
This PR adds two commands that check membership within an organization. This check can be performed with a user's ID (`launch github access check-user`) or with a pull request ID (`launch github access check-pr`).

```
Usage: launch github access check-user [OPTIONS]

  Checks if a user is a member of an organization.

Options:
  --user-id INTEGER    The user ID of the user to check. Mutually exclusive
                       with --user-name.
  --user-name TEXT     The user name of the user to check. Mutually exclusive
                       with --user-id.
  --organization TEXT  GitHub organization to verify the user's membership.
                       Defaults to the launchbynttdata organization.
  --help               Show this message and exit.
```

```
$ launch github access check-user --user-id 132399041; echo $?
chris11-taylor-nttd is a member of launchbynttdata
0
$ launch github access check-user --user-id 182156741; echo $?
chris-testing-webhook-security is not a member of launchbynttdata
1
```

```
Usage: launch github access check-pr [OPTIONS]

  Checks if a pull request originated from inside the organization or from
  outside.

Options:
  --repository TEXT    The Repository where the pull request was opened.
                       [required]
  --pr-number INTEGER  The ID of the pull request to check.  [required]
  --organization TEXT  GitHub organization to verify the user's membership.
                       Defaults to the launchbynttdata organization.
  --help               Show this message and exit.
```

```sh
$ launch github access check-pr --repository tf-aws-module_primitive-api_gateway_v2 --pr-number 5; echo $?
chris-testing-webhook-security is not a member of launchbynttdata
1
$ launch github access check-pr --repository tf-aws-module_primitive-api_gateway_v2 --pr-number 6; echo $?
chris11-taylor-nttd is a member of launchbynttdata
0
```