### PR TITLE
Add the ability to predict the type of change, not just the next version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "launch-cli"
-version = "0.14.2"
+version = "0.15.0"
 description = "CLI tooling for common Launch functions"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/launch/cli/github/version/commands.py
+++ b/src/launch/cli/github/version/commands.py
@@ -5,7 +5,7 @@ from functools import wraps
 import click
 
 from launch.lib.local_repo.branch import get_current_branch_name
-from launch.lib.local_repo.predict import predict_version
+from launch.lib.local_repo.predict import predict_change_type, predict_version
 from launch.lib.local_repo.tags import (
     CommitNotTaggedException,
     CommitTagNotSemanticVersionException,
@@ -44,16 +44,25 @@ def version_required_options_wrapper(f):
 
 
 @click.command()
+@click.option(
+    "--change-type",
+    type=click.BOOL,
+    is_flag=True,
+    help="Print the type of predicted change (e.g. 'major', 'minor', 'patch') rather than the version.",
+)
 @version_required_options_wrapper
-def predict(repo_path: pathlib.Path, source_branch: str):
+def predict(repo_path: pathlib.Path, source_branch: str, change_type: bool):
     """Predicts the next semantic version for a repository."""
 
     try:
-        predicted_version = predict_version(
-            existing_tags=read_semantic_tags(repo_path=repo_path),
-            branch_name=source_branch,
-        )
-        click.echo(predicted_version)
+        if change_type:
+            click.echo(predict_change_type(branch_name=source_branch))
+        else:
+            predicted_version = predict_version(
+                existing_tags=read_semantic_tags(repo_path=repo_path),
+                branch_name=source_branch,
+            )
+            click.echo(predicted_version)
     except Exception as e:
         click.secho(
             f"Failed to predict next version for repository at {repo_path}: {e}",

--- a/test/unit/cli/github/test_version_predict.py
+++ b/test/unit/cli/github/test_version_predict.py
@@ -1,0 +1,74 @@
+import pytest
+from git.repo import Repo
+
+from launch.cli.github.version import commands
+
+
+@pytest.fixture(scope="function")
+def example_github_repo(tmp_path):
+    temp_repo = Repo.init(path=tmp_path, initial_branch="main")
+    tmp_path.joinpath("test.txt").write_text("Sample file")
+    temp_repo.index.add("test.txt")
+    temp_repo.index.commit("Added test.txt")
+    temp_repo.create_tag("0.1.0")
+    yield temp_repo
+
+
+class TestVersionPredictionCLI:
+    def test_predict_version_fails_with_missing_params(self, cli_runner):
+        result = cli_runner.invoke(
+            commands.predict,
+            [],
+        )
+        assert result.exception
+        assert result.exit_code != 0
+        assert "Missing option '--source-branch'" in result.output
+
+    @pytest.mark.parametrize(
+        "branch_name, expected_version",
+        [
+            ("fix/foo", "0.1.1"),
+            ("feature/bar", "0.2.0"),
+            ("feature!/baz", "1.0.0"),
+        ],
+    )
+    def test_predict_version_number(
+        self, branch_name: str, expected_version: str, cli_runner, example_github_repo
+    ):
+        result = cli_runner.invoke(
+            commands.predict,
+            [
+                "--source-branch",
+                branch_name,
+                "--repo-path",
+                str(example_github_repo.working_dir),
+            ],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+        assert result.output.strip() == expected_version
+
+    @pytest.mark.parametrize(
+        "branch_name, expected_type",
+        [
+            ("fix/foo", "patch"),
+            ("feature/bar", "minor"),
+            ("feature!/baz", "major"),
+        ],
+    )
+    def test_predict_version_change_type(
+        self, branch_name: str, expected_type: str, cli_runner, example_github_repo
+    ):
+        result = cli_runner.invoke(
+            commands.predict,
+            [
+                "--source-branch",
+                branch_name,
+                "--repo-path",
+                str(example_github_repo.working_dir),
+                "--change-type",
+            ],
+        )
+        assert not result.exception
+        assert result.exit_code == 0
+        assert result.output.strip() == expected_type


### PR DESCRIPTION
Adds a `--change-type` flag to the `launch github version predict` command to predict the type of change rather than the next version:

```sh
$ launch github version predict --change-type --source-branch "fix/foo"
patch
$ launch github version predict --change-type --source-branch "feature/bar"
minor
$ launch github version predict --change-type --source-branch "feature\!/baz"
major
```